### PR TITLE
*: Use go.f110.dev/xerrors instead of golang.org/x/xerrors

### DIFF
--- a/cmd/gomodule-proxy/BUILD.bazel
+++ b/cmd/gomodule-proxy/BUILD.bazel
@@ -14,8 +14,8 @@ go_library(
         "@com_github_google_go_github_v40//github:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@com_github_spf13_pflag//:go_default_library",
+        "@dev_f110_go_xerrors//:go_default_library",
         "@org_golang_x_oauth2//:go_default_library",
-        "@org_golang_x_xerrors//:go_default_library",
     ],
 )
 

--- a/cmd/gomodule-proxy/internal/config/BUILD.bazel
+++ b/cmd/gomodule-proxy/internal/config/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     importpath = "go.f110.dev/gomodule-proxy/cmd/gomodule-proxy/internal/config",
     visibility = ["//cmd/gomodule-proxy:__subpackages__"],
     deps = [
+        "@dev_f110_go_xerrors//:go_default_library",
         "@in_gopkg_yaml_v2//:go_default_library",
-        "@org_golang_x_xerrors//:go_default_library",
     ],
 )

--- a/cmd/gomodule-proxy/internal/config/config.go
+++ b/cmd/gomodule-proxy/internal/config/config.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"regexp"
 
-	"golang.org/x/xerrors"
+	"go.f110.dev/xerrors"
 	"gopkg.in/yaml.v2"
 )
 
@@ -19,17 +19,17 @@ type Config []*ModuleSetting
 func ReadConfig(path string) (Config, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, xerrors.Errorf(": %w", err)
+		return nil, xerrors.WithStack(err)
 	}
 
 	var conf Config
 	if err := yaml.NewDecoder(f).Decode(&conf); err != nil {
-		return nil, xerrors.Errorf(": %w", err)
+		return nil, xerrors.WithStack(err)
 	}
 	for _, v := range conf {
 		re, err := regexp.Compile(v.ModuleName)
 		if err != nil {
-			return nil, xerrors.Errorf(": %w", err)
+			return nil, xerrors.WithStack(err)
 		}
 		v.match = re
 	}

--- a/cmd/gomodule-proxy/main.go
+++ b/cmd/gomodule-proxy/main.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/cobra"
 )
 
-func goModuleProxy(args []string) error {
+func goModuleProxy() error {
 	proxy := newGoModuleProxyCommand()
 
 	cmd := &cobra.Command{
@@ -26,12 +29,13 @@ func goModuleProxy(args []string) error {
 		}
 	}
 
-	cmd.SetArgs(args)
-	return cmd.Execute()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return cmd.ExecuteContext(ctx)
 }
 
 func main() {
-	if err := goModuleProxy(os.Args); err != nil {
+	if err := goModuleProxy(); err != nil {
 		format := "%v\n"
 		if os.Getenv("DEBUG") != "" {
 			format = "%+v\n"

--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,10 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
+	go.f110.dev/xerrors v0.0.0-20241005060613-5d51f0ed30e0
 	golang.org/x/mod v0.25.0
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/tools/go/vcs v0.1.0-deprecated
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -37,6 +37,8 @@ require (
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.39.0 // indirect
 	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -189,11 +189,19 @@ github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+go.f110.dev/xerrors v0.0.0-20241005060613-5d51f0ed30e0 h1:Dkz+46Dlfi51SM5pmELpR8FiR/+cP/oaIGw2nXYCAw0=
+go.f110.dev/xerrors v0.0.0-20241005060613-5d51f0ed30e0/go.mod h1:cES3zXhfCuKnA7lnN4m3sivaMsBU/IlIl7yVw1VaN28=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -374,7 +382,6 @@ golang.org/x/tools/go/vcs v0.1.0-deprecated/go.mod h1:zUrvATBAvEI9535oC0yWYsLsHI
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/internal/gomodule/BUILD.bazel
+++ b/internal/gomodule/BUILD.bazel
@@ -16,10 +16,10 @@ go_library(
         "@com_github_go_git_go_git_v5//plumbing/object:go_default_library",
         "@com_github_google_go_github_v40//github:go_default_library",
         "@com_github_gorilla_mux//:go_default_library",
+        "@dev_f110_go_xerrors//:go_default_library",
         "@org_golang_x_mod//modfile",
         "@org_golang_x_mod//semver",
         "@org_golang_x_tools_go_vcs//:vcs",
-        "@org_golang_x_xerrors//:go_default_library",
     ],
 )
 

--- a/internal/gomodule/proxy.go
+++ b/internal/gomodule/proxy.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/v40/github"
-	"golang.org/x/xerrors"
+	"go.f110.dev/xerrors"
 )
 
 const (
@@ -54,7 +54,7 @@ type Info struct {
 func (m *ModuleProxy) Versions(ctx context.Context, module string) ([]string, error) {
 	modRoot, err := m.fetcher.Fetch(ctx, module)
 	if err != nil {
-		return nil, xerrors.Errorf(": %w", err)
+		return nil, err
 	}
 	for _, mod := range modRoot.Modules {
 		if mod.Path == module {
@@ -66,13 +66,13 @@ func (m *ModuleProxy) Versions(ctx context.Context, module string) ([]string, er
 		}
 	}
 
-	return nil, xerrors.Errorf("%s is not found", module)
+	return nil, xerrors.Newf("%s is not found", module)
 }
 
 func (m *ModuleProxy) GetInfo(ctx context.Context, module, version string) (Info, error) {
 	modRoot, err := m.fetcher.Fetch(ctx, module)
 	if err != nil {
-		return Info{}, xerrors.Errorf(": %w", err)
+		return Info{}, err
 	}
 
 	var mod *Module
@@ -83,7 +83,7 @@ func (m *ModuleProxy) GetInfo(ctx context.Context, module, version string) (Info
 		}
 	}
 	if mod == nil {
-		return Info{}, xerrors.Errorf("%s is not found", module)
+		return Info{}, xerrors.Newf("%s is not found", module)
 	}
 	for _, v := range mod.Versions {
 		if version == v.Semver {
@@ -91,13 +91,13 @@ func (m *ModuleProxy) GetInfo(ctx context.Context, module, version string) (Info
 		}
 	}
 
-	return Info{}, xerrors.Errorf("%s is not found in %s", version, module)
+	return Info{}, xerrors.Newf("%s is not found in %s", version, module)
 }
 
 func (m *ModuleProxy) GetLatestVersion(ctx context.Context, module string) (Info, error) {
 	modRoot, err := m.fetcher.Fetch(ctx, module)
 	if err != nil {
-		return Info{}, xerrors.Errorf(": %w", err)
+		return Info{}, err
 	}
 
 	var mod *Module
@@ -108,7 +108,7 @@ func (m *ModuleProxy) GetLatestVersion(ctx context.Context, module string) (Info
 		}
 	}
 	if mod == nil {
-		return Info{}, xerrors.Errorf("%s is not found", module)
+		return Info{}, xerrors.Newf("%s is not found", module)
 	}
 
 	modVer := mod.Versions[len(mod.Versions)-1]
@@ -118,7 +118,7 @@ func (m *ModuleProxy) GetLatestVersion(ctx context.Context, module string) (Info
 func (m *ModuleProxy) GetGoMod(ctx context.Context, module, version string) (string, error) {
 	modRoot, err := m.fetcher.Fetch(ctx, module)
 	if err != nil {
-		return "", xerrors.Errorf(": %w", err)
+		return "", err
 	}
 
 	var mod *Module
@@ -129,12 +129,12 @@ func (m *ModuleProxy) GetGoMod(ctx context.Context, module, version string) (str
 		}
 	}
 	if mod == nil {
-		return "", xerrors.Errorf("%s is not found", module)
+		return "", xerrors.Newf("%s is not found", module)
 	}
 
 	goMod, err := mod.ModuleFile(version)
 	if err != nil {
-		return "", xerrors.Errorf(": %w", err)
+		return "", xerrors.Newf(": %w", err)
 	}
 
 	return string(goMod), nil
@@ -143,12 +143,12 @@ func (m *ModuleProxy) GetGoMod(ctx context.Context, module, version string) (str
 func (m *ModuleProxy) GetZip(ctx context.Context, w io.Writer, module, version string) error {
 	modRoot, err := m.fetcher.Fetch(ctx, module)
 	if err != nil {
-		return xerrors.Errorf(": %w", err)
+		return err
 	}
 
 	err = modRoot.Archive(w, module, version)
 	if err != nil {
-		return xerrors.Errorf(": %w", err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION

---

Pull request chain:

1. #7
1. #8
1. #9
1. 👉 #10
1. #11
